### PR TITLE
Update dependencies and bounds for GHC 8.8

### DIFF
--- a/regex-pcre-text.cabal
+++ b/regex-pcre-text.cabal
@@ -2,7 +2,7 @@ Name:                   regex-pcre-text
 Version:                0.94.0.1
 Synopsis:               Text-based PCRE API for regex-base
 Description:            The PCRE/Text backend to accompany regex-base;
-                        needs regex-pcre and regex-tdfa-text
+                        needs regex-pcre and regex-tdfa
 Homepage:               https://github.com/cdornan/regex-pcre-text
 Author:                 Chris Dornan and Christopher Kuklewicz
 License:                BSD3
@@ -48,7 +48,7 @@ Library
         base                 >= 4       && < 5
       , array                >= 0.4     && < 0.6
       , bytestring           == 0.10.*
-      , regex-base           == 0.93.*
-      , regex-pcre-builtin   == 0.94.*
-      , regex-tdfa-text      == 1.0.*
+      , regex-base           >= 0.93    && < 0.95
+      , regex-pcre-builtin   >= 0.94    && < 0.96
+      , regex-tdfa           >= 1.3.1.0 && < 1.4
       , text                 == 1.2.*


### PR DESCRIPTION
- As of regex-tdfa 1.3.1.0 the regex-tdfa-text patches are merged and the
  latter package is deprecated.

- Bounds updated for newer versions of regex-base and regex-pcre-builtin